### PR TITLE
Use Travis CI to run tests on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8 tensorflow  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - python run_basics.py #Can run only with python and tensorflow
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-    - python run_basics.py #Can run only with python and tensorflow
+    - python run_basics.py  # Can run only with python and tensorflow
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Travis Continuous Integration can run automated testing using __python run_basics.py__ and [flake8](http://flake8.pycqa.org).  The Travis CI is free for all open source projects like this one and to turn it on, visit https://travis-ci.org/profile  This config file will have Travis CI run flake8 tests on all pull requests before they are reviewed.