### PR TITLE
Travis CI: pip install -r requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
 install:
     #- pip install -r requirements.txt
     - pip install flake8 scikit-image scipy tensorflow  # pytest  # add another testing frameworks later
+    - pip install numpy --upgrade --ignore-installed
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - python: pypy3
 install:
     #- pip install -r requirements.txt
-    - pip install flake8 scipy tensorflow  # pytest  # add another testing frameworks later
+    - pip install flake8 scikit-image scipy tensorflow  # pytest  # add another testing frameworks later
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - python: pypy3
 install:
     #- pip install -r requirements.txt
-    - pip install flake8 tensorflow  # pytest  # add another testing frameworks later
+    - pip install flake8 scipy tensorflow  # pytest  # add another testing frameworks later
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ matrix:
         - python: pypy
         - python: pypy3
 install:
-    #- pip install -r requirements.txt
-    - pip install flake8 scikit-image scipy tensorflow  # pytest  # add another testing frameworks later
-    - pip install numpy --upgrade --ignore-installed
+    - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy>=1.14.3
+scikit-image
+scipy
+tensorflow


### PR DESCRIPTION
This PR adds a __requirements.txt__ file with the dependencies which fixes the import errors in the Travis tests but is still an issue that when __python run_basics.py__ is run, the message [__please download PRN trained model first.__](https://travis-ci.com/YadiraF/PRNet/jobs/123111071#L1041) is printed.