### PR TITLE
skimage >= 0.16, rescale need to set multichannel=True

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -50,7 +50,10 @@ def main(args):
         if args.isDlib:
             max_size = max(image.shape[0], image.shape[1])
             if max_size> 1000:
-                image = rescale(image, 1000./max_size)
+                try:
+                    image = rescale(image, 1000./max_size,multichannel=True)
+                except:
+                    image = rescale(image, 1000./max_size)
                 image = (image*255).astype(np.uint8)
             pos = prn.process(image) # use dlib to detect face
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.14.3
 scikit-image
 scipy
-tensorflow
+tensorflow<2.0.0


### PR DESCRIPTION
In `skimage >= 0.16`, When use `skimage.transform.rescale` need to set parameter `multichannel=True` to rescale the image
if it isn't set it will crash when input image larger than 1000 pixel in width or height because output  of `rescale` will be 1 channel instead of 3 channels.

**To reproduce bug:**
1. set environment which is install ` skimage`  version ` 0.16`  or newer.
2. input [this image](https://i.imgur.com/s9I0Zbh.jpg) to **demo.py** with `--isDlib=True`
3. boom!

**Tracekback from my PC.**

```
Traceback (most recent call last):
  File "demo.py", line 168, in <module>
    main(parser.parse_args())
  File "demo.py", line 56, in main
    pos = prn.process(image) # use dlib to detect face
  File "/home/pakkapon/PRNet/api.py", line 120, in process
    cropped_pos = self.net_forward(cropped_image)
  File "/home/pakkapon/PRNet/api.py", line 62, in net_forward
    return self.pos_predictor.predict(image)
  File "/home/pakkapon/PRNet/predictor.py", line 98, in predict
    feed_dict = {self.x: image[np.newaxis, :,:,:]})
  File "/home/pakkapon/.virtualenv/prnet/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 950, in run
    run_metadata_ptr)
  File "/home/pakkapon/.virtualenv/prnet/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1149, in _run
    str(subfeed_t.get_shape())))
ValueError: Cannot feed value of shape (1, 256, 256, 1) for Tensor 'Placeholder:0', which has shape '(?, 256, 256, 3)'
```

Best regrad
Pakkapon