### PR TITLE
Improve depth map rasterization time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# C extensions
+*.so
+*.o
+*.pyc
+
+utils/fast_render/build

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ What you can custom:
 
    you can refer to  [c++ version](https://github.com/YadiraF/face3d/blob/master/face3d/mesh/render.py). 
 
+   Another alternative is to use the C++ already in this repo, integrated with ctypes. You must install both CMake and a C++ compiler, then run the following command: 
+   ```
+   sh build.sh
+   ```
+   This code only implements the hotpath of rendering the face depth map. The speedup from a 256x256 image was from 2681ms to 1.8ms, quite a difference.
+
    c. other parts like detecting face, writing obj
 
    the best way is to rewrite them in c++.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+cd utils/fast_render
+mkdir build
+cd build
+cmake ..
+make

--- a/utils/fast_render/CMakeLists.txt
+++ b/utils/fast_render/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(fast_render VERSION 0.0.1)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wfatal-errors -O2")
+
+include_directories(
+    "src/"
+)
+
+file(GLOB all_fast_render_src
+    "src/*.cpp"
+)
+
+add_library(fast_render SHARED ${all_fast_render_src})

--- a/utils/fast_render/fast_render.py
+++ b/utils/fast_render/fast_render.py
@@ -1,0 +1,37 @@
+import ctypes
+import numpy as np
+from numpy.ctypeslib import ndpointer
+
+lib = ctypes.CDLL('./build/libfast_render.so')
+
+c_render_texture_loop = lib.render_texture_loop
+c_render_texture_loop.argtypes = [
+    ndpointer(ctypes.c_double, flags='C_CONTIGUOUS'), # tri_depth
+    ctypes.c_int,
+    ndpointer(ctypes.c_double, flags='C_CONTIGUOUS'), # tri_tex
+    ctypes.c_int,
+    ctypes.c_int,
+    ndpointer(ctypes.c_int, flags='C_CONTIGUOUS'), # triangles
+    ctypes.c_int,
+    ctypes.c_int,
+    ndpointer(ctypes.c_double, flags='C_CONTIGUOUS'), # vertices
+    ctypes.c_int,
+    ctypes.c_int,
+    ndpointer(ctypes.c_double, flags='C_CONTIGUOUS'), # depth_buffer
+    ctypes.c_int,
+    ctypes.c_int,
+    ndpointer(ctypes.c_double, flags='C_CONTIGUOUS'), # image
+    ctypes.c_int,
+    ctypes.c_int,
+]
+
+
+def render_texture_loop(tri_depth, tri_tex, triangles, vertices, depth_buffer, image):
+    c_render_texture_loop(
+            tri_depth, tri_depth.shape[0],
+            tri_tex, tri_tex.shape[1], tri_tex.shape[0],
+            triangles, triangles.shape[1], triangles.shape[0],
+            vertices, vertices.shape[1], vertices.shape[0],
+            depth_buffer, depth_buffer.shape[1], depth_buffer.shape[0],
+            image, image.shape[1], image.shape[0]
+        )

--- a/utils/fast_render/fast_render.py
+++ b/utils/fast_render/fast_render.py
@@ -2,7 +2,7 @@ import ctypes
 import numpy as np
 from numpy.ctypeslib import ndpointer
 
-lib = ctypes.CDLL('./build/libfast_render.so')
+lib = ctypes.CDLL('./utils/fast_render/build/libfast_render.so')
 
 c_render_texture_loop = lib.render_texture_loop
 c_render_texture_loop.argtypes = [

--- a/utils/fast_render/fast_render.py
+++ b/utils/fast_render/fast_render.py
@@ -27,11 +27,16 @@ c_render_texture_loop.argtypes = [
 
 
 def render_texture_loop(tri_depth, tri_tex, triangles, vertices, depth_buffer, image):
+    if len(image.shape) == 2:
+        image_channels = 1
+    else:
+        image_channels = image.shape[2]
+
     c_render_texture_loop(
             tri_depth, tri_depth.shape[0],
             tri_tex, tri_tex.shape[1], tri_tex.shape[0],
             triangles, triangles.shape[1], triangles.shape[0],
             vertices, vertices.shape[1], vertices.shape[0],
             depth_buffer, depth_buffer.shape[1], depth_buffer.shape[0],
-            image, image.shape[1], image.shape[0]
+            image, image.shape[1], image.shape[0], image_channels
         )

--- a/utils/fast_render/src/render.cpp
+++ b/utils/fast_render/src/render.cpp
@@ -1,5 +1,15 @@
 #include "render.h"
 
+
+bool PointInTriangle(double p_x, double p_y, double p0_x, double p0_y, double p1_x, double p1_y, double p2_x, double p2_y) {
+    float A = 1/2 * (-p1_y * p2_x + p0_y * (-p1_x + p2_x) + p0_x * (p1_y - p2_y) + p1_x * p2_y);
+    float sign = A < 0 ? -1 : 1;
+    float s = (p0_y * p2_x - p0_x * p2_y + (p2_y - p0_y) * p_x + (p0_x - p2_x) * p_y) * sign;
+    float t = (p0_x * p1_y - p0_y * p1_x + (p0_y - p1_y) * p_x + (p1_x - p0_x) * p_y) * sign;
+
+    return s > 0 && t > 0 && (s + t) < 2 * A * sign;
+}
+
 void render_texture_loop(const double *tri_depth, int tri_depth_height,
         const double *tri_tex, int tri_tex_width, int tri_tex_height,
         const int *triangles, int triangles_width, int triangles_height,
@@ -35,7 +45,7 @@ void render_texture_loop(const double *tri_depth, int tri_depth_height,
         for (int u = umin; u<umax+1; u++) {
             for (int v = vmin; v<vmax+1; v++) {
                 if (tri_depth[i] > depth_buffer[v*depth_buffer_width + u]) {
-                    if (true) { //isPointInTri(u, v, v1_u, v2_u, v3_u, v1_v, v2_v, v3_v)) {
+                    if (PointInTriangle(u, v, v1_u, v2_u, v3_u, v1_v, v2_v, v3_v)) {
                         depth_buffer[v*depth_buffer_width + u] = tri_depth[i];
                         for (int aux=0; aux<tri_tex_height; aux++) {
                             image[v*image_width + u] = tri_tex[aux*tri_tex_width + i];

--- a/utils/fast_render/src/render.cpp
+++ b/utils/fast_render/src/render.cpp
@@ -1,13 +1,16 @@
 #include "render.h"
 
 
-bool PointInTriangle(double p_x, double p_y, double p0_x, double p0_y, double p1_x, double p1_y, double p2_x, double p2_y) {
-    float A = 1/2 * (-p1_y * p2_x + p0_y * (-p1_x + p2_x) + p0_x * (p1_y - p2_y) + p1_x * p2_y);
-    float sign = A < 0 ? -1 : 1;
-    float s = (p0_y * p2_x - p0_x * p2_y + (p2_y - p0_y) * p_x + (p0_x - p2_x) * p_y) * sign;
-    float t = (p0_x * p1_y - p0_y * p1_x + (p0_y - p1_y) * p_x + (p1_x - p0_x) * p_y) * sign;
+bool PointInTriangle(double p_x, double p_y, double p0_x, double p1_x, double p2_x, double p0_y, double p1_y,  double p2_y) {
+    // Original code from here: https://github.com/SebLague/Gamedev-Maths/blob/master/PointInTriangle.cs
+    double s1 = p2_y - p0_y;
+    double s2 = p2_x - p0_x;
+    double s3 = p1_y - p0_y;
+    double s4 = p_y - p0_y;
 
-    return s > 0 && t > 0 && (s + t) < 2 * A * sign;
+    double w1 = (p0_x * s1 + s4 * s2 - p_x * s1) / (s3 * s2 - (p1_x-p0_x) * s1);
+    double w2 = (s4- w1 * s3) / s1;
+    return w1 >= 0 && w2 >= 0 && (w1 + w2) <= 1;
 }
 
 void render_texture_loop(const double *tri_depth, int tri_depth_height,
@@ -45,7 +48,7 @@ void render_texture_loop(const double *tri_depth, int tri_depth_height,
         for (int u = umin; u<umax+1; u++) {
             for (int v = vmin; v<vmax+1; v++) {
                 if (tri_depth[i] > depth_buffer[v*depth_buffer_width + u]) {
-                    if (PointInTriangle(u, v, v1_u, v2_u, v3_u, v1_v, v2_v, v3_v)) {
+                    if (PointInTriangle((double)u, (double)v, v1_u, v2_u, v3_u, v1_v, v2_v, v3_v)) {
                         depth_buffer[v*depth_buffer_width + u] = tri_depth[i];
                         for (int aux=0; aux<tri_tex_height; aux++) {
                             image[v*image_width + u] = tri_tex[aux*tri_tex_width + i];

--- a/utils/fast_render/src/render.cpp
+++ b/utils/fast_render/src/render.cpp
@@ -18,7 +18,7 @@ void render_texture_loop(const double *tri_depth, int tri_depth_height,
         const int *triangles, int triangles_width, int triangles_height,
         const double *vertices, int vertices_width, int vertices_height,
         double *depth_buffer, int depth_buffer_width, int depth_buffer_height,
-        double *image, int image_width, int image_height)
+        double *image, int image_width, int image_height, int image_channels)
 {
     for (int i=0; i<triangles_width; i++) {
         // 3 vertex indices
@@ -51,7 +51,9 @@ void render_texture_loop(const double *tri_depth, int tri_depth_height,
                     if (PointInTriangle((double)u, (double)v, v1_u, v2_u, v3_u, v1_v, v2_v, v3_v)) {
                         depth_buffer[v*depth_buffer_width + u] = tri_depth[i];
                         for (int aux=0; aux<tri_tex_height; aux++) {
-                            image[v*image_width + u] = tri_tex[aux*tri_tex_width + i];
+                            for (int c=0; c<image_channels; c++) {
+                                image[v*image_width*image_channels + u*image_channels + c] = tri_tex[aux*tri_tex_width + i];
+                            }
                         }
                     }
                 }

--- a/utils/fast_render/src/render.cpp
+++ b/utils/fast_render/src/render.cpp
@@ -1,0 +1,49 @@
+#include "render.h"
+
+void render_texture_loop(const double *tri_depth, int tri_depth_height,
+        const double *tri_tex, int tri_tex_width, int tri_tex_height,
+        const int *triangles, int triangles_width, int triangles_height,
+        const double *vertices, int vertices_width, int vertices_height,
+        double *depth_buffer, int depth_buffer_width, int depth_buffer_height,
+        double *image, int image_width, int image_height)
+{
+    for (int i=0; i<triangles_width; i++) {
+        // 3 vertex indices
+        int tri1 = triangles[0*triangles_width+i];
+        int tri2 = triangles[1*triangles_width+i];
+        int tri3 = triangles[2*triangles_width+i];
+
+        double v1_u = vertices[0*vertices_width+tri1];
+        double v2_u = vertices[0*vertices_width+tri2];
+        double v3_u = vertices[0*vertices_width+tri3];
+
+        double v1_v = vertices[1*vertices_width+tri1];
+        double v2_v = vertices[1*vertices_width+tri2];
+        double v3_v = vertices[1*vertices_width+tri3];
+
+
+        // the inner bounding box
+        int umin = std::max(ceil(std::min(std::min(v1_u,v2_u),v3_u)), 0.0);
+        int umax = std::min(floor(std::max(std::max(v1_u,v2_u),v3_u)), double(image_width-1));
+
+        int vmin = std::max(ceil(std::min(std::min(v1_v,v2_v),v3_v)), 0.0);
+        int vmax = std::min(floor(std::max(std::max(v1_v,v2_v),v3_v)), double(image_height-1));
+
+        if (umax<umin || vmax<vmin)
+            continue;
+
+        for (int u = umin; u<umax+1; u++) {
+            for (int v = vmin; v<vmax+1; v++) {
+                if (tri_depth[i] > depth_buffer[v*depth_buffer_width + u]) {
+                    if (true) { //isPointInTri(u, v, v1_u, v2_u, v3_u, v1_v, v2_v, v3_v)) {
+                        depth_buffer[v*depth_buffer_width + u] = tri_depth[i];
+                        for (int aux=0; aux<tri_tex_height; aux++) {
+                            image[v*image_width + u] = tri_tex[aux*tri_tex_width + i];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/utils/fast_render/src/render.h
+++ b/utils/fast_render/src/render.h
@@ -12,6 +12,6 @@ extern "C" {
             const int *triangles, int triangles_width, int triangles_height,
             const double *vertices, int vertices_width, int vertices_height,
             double *depth_buffer, int depth_buffer_width, int depth_buffer_height,
-            double *image, int image_width, int image_height
+            double *image, int image_width, int image_height, int image_channels
         );
 }

--- a/utils/fast_render/src/render.h
+++ b/utils/fast_render/src/render.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string.h>
+#include <stdio.h>
+#include <math.h> // ceil
+#include <algorithm> // min max
+
+extern "C" {
+    void render_texture_loop(
+            const double *tri_depth, int tri_depth_height,
+            const double *tri_tex, int tri_tex_width, int tri_tex_height,
+            const int *triangles, int triangles_width, int triangles_height,
+            const double *vertices, int vertices_width, int vertices_height,
+            double *depth_buffer, int depth_buffer_width, int depth_buffer_height,
+            double *image, int image_width, int image_height
+        );
+}

--- a/utils/render.py
+++ b/utils/render.py
@@ -5,8 +5,11 @@ Mail: fengyao@sjtu.edu.cn
 import numpy as np
 try:
     from utils.fast_render import fast_render
+    using_fast_render = True
 except BaseException as e:
-    print(e)
+    print("INFO - You can run 'sh build.sh' to build a faster "
+            "rendering function for the depthmap images")
+    using_fast_render = False
 
 def isPointInTri(point, tri_points):
     ''' Judge whether the point is in the triangle
@@ -106,9 +109,9 @@ def render_texture(vertices, colors, triangles, h, w, c = 3):
     triangles = np.ascontiguousarray(triangles)
     vertices = np.ascontiguousarray(vertices)
 
-    try:
+    if using_fast_render:
         fast_render.render_texture_loop(tri_depth, tri_tex, triangles, vertices, depth_buffer, image)
-    except:
+    else:
         for i in range(triangles.shape[1]):
             tri = triangles[:, i] # 3 vertex indices
 


### PR DESCRIPTION
The main point of this PR is to greatly improve the runtime of depth map rasterization. It is currently written on Python and this PR takes only the hot loop and codes it in C++.

The main guiding points here:
1 - Don't break compatibility. Every user of PRNet should be using the code in the same way, without installing any additional dependency or doing extra steps. So the code will gracefully fallback to the original Python code if the user do not compile the C++ code.
2 - Easy to use. The compilation step is quite simple, and a build.sh script is available for Unix users. Also the required dependencies to compile are a C++ compiler and cmake to make life easier on different OSes. So no additional libs or tools are required.
3 - Touch the minimal amount of code so that the debugging and maintenance process stays as much as possible on Python.
4 - Must be quite fast. For a 250x250 image, the runtime went from 2376ms to 2.152ms on a i7-8700K. Notice that no threads o parallel computing was used, it was just a plain conversion from the Python code to C++.

I've noticed that there is a cython implementation, however it is on another repo, and it may be hard to setup for people that do not have any cython knowledge.

On a side note, amazing work on PRNet! :D